### PR TITLE
Fix crash on decrypt

### DIFF
--- a/DUKPT.m
+++ b/DUKPT.m
@@ -265,7 +265,7 @@ NSData* ksnData;
             NSString* blockPrev = [data substringWithRange:NSMakeRange(x - 16, 16)];
             decryptedBlock = [self xorData:decryptedBlock withData:[self dataFromString:blockPrev]];
         }
-        NSString *myString = [[NSString alloc] initWithData:decryptedBlock encoding:NSUTF8StringEncoding];
+        NSString *myString = [[NSString alloc] initWithData:decryptedBlock encoding:NSASCIIStringEncoding];
         [result insertString:myString atIndex:0];
     }
     return result;


### PR DESCRIPTION
This fixes a bug that is reproducible from some output from card swipers like Magtek's eDynamo, and I'm sure others. This is documented in #2 and resolves that issue.

The issue is the input string is not UTF8, it's ASCII. When decoding the data with `NSUTF8StringEncoding` the string won't be created, and `nil` will come back instead. This is what ultimately leads to the crash.
